### PR TITLE
Allow NAN values in input raw data.

### DIFF
--- a/atek/data_preprocess/frame_data_processor.py
+++ b/atek/data_preprocess/frame_data_processor.py
@@ -117,7 +117,6 @@ class FrameDataProcessor:
         self.T_device_camera = self.final_camera_calib.get_transform_device_camera()
 
         self.update_df_with_poseinfo()
-        self.cleanup_df()
 
         if self.gt_data_processor is not None:
             self.gt_data_processor.set_undistortion_params(
@@ -130,16 +129,6 @@ class FrameDataProcessor:
 
     def __len__(self):
         return len(self.frame_df)
-
-    def cleanup_df(self):
-        valid_df = self.frame_df.dropna()
-        invalid_count = len(self.frame_df) - len(valid_df)
-        invalid_percent = (invalid_count / len(self.frame_df)) * 100
-        logger.info(
-            f"Dropped {invalid_percent} percent ({invalid_count}/{len(self.frame_df)}) frames without required GT information."
-        )
-        self.frame_df = valid_df
-        self.frame_df.reset_index(drop=True, inplace=True)
 
     def get_T_device_camera(self) -> SE3:
         return self.T_device_camera

--- a/atek/data_preprocess/pose_data_processor.py
+++ b/atek/data_preprocess/pose_data_processor.py
@@ -56,25 +56,26 @@ class PoseDataProcessor:
         """
         if isinstance(timestamps_ns, List):
             timestamps_ns = np.array(timestamps_ns)
+        SHARED_TIMESTAMP_HEADER_NAME = "tracking_timestamp_us"
 
         timestamps_us_df = pd.DataFrame(
             {
-                "tracking_timestamp_us": pd.Series(
+                SHARED_TIMESTAMP_HEADER_NAME: pd.Series(
                     np.round(timestamps_ns / 1000).astype(int)
                 )
             }
         )
-        timestamps_us_df = timestamps_us_df.sort_values("tracking_timestamp_us")
+        timestamps_us_df = timestamps_us_df.sort_values(SHARED_TIMESTAMP_HEADER_NAME)
 
         merged_df = pd.merge_asof(
             timestamps_us_df,
             self.traj_df,
-            on="tracking_timestamp_us",
+            on=SHARED_TIMESTAMP_HEADER_NAME,
             tolerance=int(round(tolerance_ns / 1000)),
             direction="nearest",
         )
 
-        valid_merged_df = merged_df.dropna()
+        valid_merged_df = merged_df.dropna(subset=[SHARED_TIMESTAMP_HEADER_NAME])
 
         invalid_count = len(merged_df) - len(valid_merged_df)
         invalid_percent = (invalid_count / len(merged_df)) * 100


### PR DESCRIPTION
Summary: The ASE-converted datasets have a number of "fake" columns that has `NAN` values in them, therefore this `cleanup_df()` function will basically remove everything. I'm wondering if this function is meant to capture any NaN values in specific fields? Happy to add a filtering for these specific fields.

Differential Revision: D53791411


